### PR TITLE
Fix keyword case sensitivity in scanner

### DIFF
--- a/src/compiler/scanner.rs
+++ b/src/compiler/scanner.rs
@@ -159,8 +159,7 @@ impl<'a> Scanner<'a> {
         }
 
         let text = self.source[self.start..self.current].to_string();
-        let lowercase_text = text.to_lowercase();
-        let token: TokenType = lowercase_text.parse().unwrap_or(TokenType::IDENTIFIER);
+        let token: TokenType = text.parse().unwrap_or(TokenType::IDENTIFIER);
         self.add_token(token);
     }
 

--- a/tests/scanner/keywords.rs
+++ b/tests/scanner/keywords.rs
@@ -70,4 +70,18 @@ fn test_keywords_as_identifiers() {
     assert_eq!(tokens[1].token_type, TokenType::IDENTIFIER, "Expected IDENTIFIER for 'classy', got {:?}", tokens[1].token_type);
     assert_eq!(tokens[2].token_type, TokenType::IDENTIFIER, "Expected IDENTIFIER for 'notelse', got {:?}", tokens[2].token_type);
     reporter.assert_no_errors();
-} 
+}
+
+#[test]
+fn test_keyword_case_sensitivity() {
+    let (tokens, reporter) = scan("AND or TRUE false");
+    assert_token_sequence(&tokens, &[
+        TokenType::IDENTIFIER,
+        TokenType::OR,
+        TokenType::IDENTIFIER,
+        TokenType::FALSE,
+    ]);
+    assert_eq!(tokens[0].lexeme, "AND");
+    assert_eq!(tokens[2].lexeme, "TRUE");
+    reporter.assert_no_errors();
+}


### PR DESCRIPTION
## Summary
- ensure the scanner treats keywords in a case-sensitive manner
- add regression test for case sensitivity

## Testing
- `cargo test -- --nocapture`

------
https://chatgpt.com/codex/tasks/task_e_684067d8ab10832c94481985b3402954