### PR TITLE
Add interpreter test

### DIFF
--- a/tests/interpreter/mod.rs
+++ b/tests/interpreter/mod.rs
@@ -1,8 +1,36 @@
-use lox::compiler::{Token, TokenType};
 use crate::common::TestErrorReporter;
+use lox::compiler::{Interpreter, Parser, Scanner};
 
 #[test]
-fn test_placeholder() {
-    // Interpreter tests will be implemented here
-    assert!(true);
-} 
+fn test_interpret_simple_script() {
+    let source = r#"
+        fun add(a, b) {
+            return a + b;
+        }
+
+        print add(2, 3);
+        print "Hello, World!";
+    "#;
+
+    // Scan the source into tokens
+    let mut reporter = TestErrorReporter::new();
+    let tokens = {
+        let mut scanner = Scanner::new(source.to_string(), &mut reporter);
+        scanner.scan_tokens();
+        scanner.tokens.clone()
+    };
+
+    // Parse the tokens into statements
+    let mut parser = Parser::new(&tokens);
+    let statements = parser
+        .parse()
+        .expect("Parser should succeed on valid source");
+
+    // Interpret the statements
+    let mut interpreter = Interpreter::new();
+    let result = interpreter.interpret(statements);
+
+    assert!(result.is_ok(), "Interpreter failed: {:?}", result.err());
+    reporter.assert_no_errors();
+    reporter.assert_no_runtime_errors();
+}

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -2,8 +2,10 @@ mod scanner;
 mod common;
 mod parser;
 mod functions;
+mod interpreter;
 
 pub use scanner::*;
 pub use common::*;
 pub use parser::*;
 pub use functions::*;
+pub use interpreter::*;


### PR DESCRIPTION
## Summary
- add an interpreter test that runs a simple script
- wire up the interpreter test module so it runs with the rest of the suite

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6840694a420c832c85ac4d5da6c2c137