### PR TITLE
Fix token comment typo

### DIFF
--- a/src/compiler/token.rs
+++ b/src/compiler/token.rs
@@ -1,7 +1,7 @@
 use std::fmt;
 use std::str::FromStr;
 
-// Estalish basic token types for the lexer
+// Establish basic token types for the lexer
 #[derive(Debug, PartialEq, Clone)]
 pub enum TokenType {
     // single char tokens


### PR DESCRIPTION
## Summary
- correct minor typo in `token.rs`

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_684069517854832c91db1a9d57f71f53